### PR TITLE
Fix regression with Reason 3.3.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,6 @@ build:
 	# Creating ocamlBetterErrors.opam so that jbuilder builds.
 	jbuilder build -j 8
 
-install: build 
-	esy-installer
-
 test:
 	jbuilder runtest
 

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     ],
     "install": [
       [
-        "make",
-        "install"
+        "esy-installer",
+        "refmterr.install"
       ]
     ],
     "buildsInSource": "_build"


### PR DESCRIPTION
__Issue:__ When using `refmterr@3.1.7` with the newly released `reason@3.3.5` in a fresh project, I see a build failure for refmterr:
```
jbuilder build -j 8
esy-installer
make: esy-installer: Command not found
make: *** [install] Error 127
```

__Defect:__ It seems that the `esy-installer` package was removed from reason in https://github.com/facebook/reason/pull/2241, which is great! However, there is an implicit dependency here - we're assuming that esy-installer is available in the path from the Makefile, and there is no explicit dependency, so now our Makefile breaks when we try to invoke esy-installer.

__Fix:__ Esy has a built-in esy-installer functionality now, but it is not accessible from the Makefile - we need to move that invocation to the package.json

cc @andreypopp 